### PR TITLE
Add ACE3 compatibility for SOG Praire Fire

### DIFF
--- a/addons/sogpf_ace/$PBOPREFIX$
+++ b/addons/sogpf_ace/$PBOPREFIX$
@@ -1,0 +1,1 @@
+z\cvo_compats\addons\sogpf_ace

--- a/addons/sogpf_ace/CfgVehicles.hpp
+++ b/addons/sogpf_ace/CfgVehicles.hpp
@@ -1,3 +1,5 @@
 class CfgVehicles {
-    #include "inc_CfgVehicles_Heli.hpp"
+    #include "CfgVehicles\helicopters.hpp"
+    #include "CfgVehicles\tracked.hpp"
+    #include "CfgVehicles\wheeled.hpp"
 };

--- a/addons/sogpf_ace/CfgVehicles.hpp
+++ b/addons/sogpf_ace/CfgVehicles.hpp
@@ -1,0 +1,3 @@
+class CfgVehicles {
+    #include "inc_CfgVehicles_Heli.hpp"
+};

--- a/addons/sogpf_ace/CfgVehicles/helicopters.hpp
+++ b/addons/sogpf_ace/CfgVehicles/helicopters.hpp
@@ -7,14 +7,14 @@ class vn_air_ch47_02_base: vn_air_ch47_transport_base {
     ace_medical_treatment_patientSeats[] = {2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19};
 };
 
-// Mi-2
+// Mi-2 Medevac
 class vn_air_mi2_base;
 class vn_air_mi2_02_base: vn_air_mi2_base {
     attendant = 1;
     ace_medical_treatment_patientSeats[] = {0};
 };
 
-// UH-1 Variants
+// UH-1 Dust-Off Variants
 class vn_air_uh1d_base;
 class vn_air_uh1d_01_base: vn_air_uh1d_base {
     attendant = 1;

--- a/addons/sogpf_ace/CfgVehicles/helicopters.hpp
+++ b/addons/sogpf_ace/CfgVehicles/helicopters.hpp
@@ -3,10 +3,20 @@ class vn_helicopter_base;
 // CH-47 Variants
 class vn_air_ch47_transport_base;
 class vn_air_ch47_02_base: vn_air_ch47_transport_base {
+    attendant = 1;
     ace_medical_treatment_patientSeats[] = {2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19};
 };
 
+// Mi-2
+class vn_air_mi2_base;
+class vn_air_mi2_02_base: vn_air_mi2_base {
+    attendant = 1;
+    ace_medical_treatment_patientSeats[] = {0};
+};
+
 // UH-1 Variants
+class vn_air_uh1d_base;
 class vn_air_uh1d_01_base: vn_air_uh1d_base {
+    attendant = 1;
     ace_medical_treatment_patientSeats[] = {0,1,2};
 };

--- a/addons/sogpf_ace/CfgVehicles/tracked.hpp
+++ b/addons/sogpf_ace/CfgVehicles/tracked.hpp
@@ -1,4 +1,5 @@
 // M577 (M113 Ambulance)
+class vn_armor_m577_base;
 class vn_armor_m577_02_base: vn_armor_m577_base {
     attendant = 1;
     ace_medical_treatment_patientSeats[] = {0,1};

--- a/addons/sogpf_ace/CfgVehicles/tracked.hpp
+++ b/addons/sogpf_ace/CfgVehicles/tracked.hpp
@@ -1,8 +1,10 @@
+// M577 (M113 Ambulance)
 class vn_armor_m577_02_base: vn_armor_m577_base {
     attendant = 1;
     ace_medical_treatment_patientSeats[] = {0,1};
 };
 
+// BTR-50 (Ambulance)
 class vn_armor_btr50pk_base;
 class vn_armor_btr50pk_03_base: vn_armor_btr50pk_base {
     attendant = 1;

--- a/addons/sogpf_ace/CfgVehicles/tracked.hpp
+++ b/addons/sogpf_ace/CfgVehicles/tracked.hpp
@@ -1,0 +1,10 @@
+class vn_armor_m577_02_base: vn_armor_m577_base {
+    attendant = 1;
+    ace_medical_treatment_patientSeats[] = {0,1};
+};
+
+class vn_armor_btr50pk_base;
+class vn_armor_btr50pk_03_base: vn_armor_btr50pk_base {
+    attendant = 1;
+    ace_medical_treatment_patientSeats[] = {0,1,2,3};
+};

--- a/addons/sogpf_ace/CfgVehicles/wheeled.hpp
+++ b/addons/sogpf_ace/CfgVehicles/wheeled.hpp
@@ -1,9 +1,11 @@
+// Dirt Ranger Ambulance
 class vn_wheeled_lr2a_base;
 class vn_wheeled_lr2a_03_base: vn_wheeled_lr2a_base {
     attendant = 1;
     ace_medical_treatment_patientSeats[] = {0,1,2,3};
 };
 
+// BTR-40 Ambulance
 class vn_wheeled_btr40_base;
 class vn_wheeled_btr40_ambulance_base: vn_wheeled_btr40_base {
     attendant = 1;

--- a/addons/sogpf_ace/CfgVehicles/wheeled.hpp
+++ b/addons/sogpf_ace/CfgVehicles/wheeled.hpp
@@ -1,0 +1,11 @@
+class vn_wheeled_lr2a_base;
+class vn_wheeled_lr2a_03_base: vn_wheeled_lr2a_base {
+    attendant = 1;
+    ace_medical_treatment_patientSeats[] = {0,1,2,3};
+};
+
+class vn_wheeled_btr40_base;
+class vn_wheeled_btr40_ambulance_base: vn_wheeled_btr40_base {
+    attendant = 1;
+    ace_medical_treatment_patientSeats[] = {3,4};
+};

--- a/addons/sogpf_ace/CfgWeapons.hpp
+++ b/addons/sogpf_ace/CfgWeapons.hpp
@@ -1,0 +1,8 @@
+class CfgWeapons {
+    class vn_b_headgear_base;
+    class vn_b_beret_04_01: vn_b_headgear_base {
+        ace_hearing_protection = 0.75;
+        ace_hearing_lowerVolume = 0.5;
+        ace_hearing_hasEHP = 0;
+    };
+};

--- a/addons/sogpf_ace/config.cpp
+++ b/addons/sogpf_ace/config.cpp
@@ -1,0 +1,22 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        name = "24th CVO Compatibilities - SOG Praire Fire ACE3";
+        author = ELSTRING(main,author);
+        url = "https://github.com/SkippieDippie/CVO-Everything-Compats";
+
+        requiredAddons[] = {
+            "air_f_vietnam_c",
+            "air_f_vietnam_02_c",
+            "ace_main"
+        };
+        requiredVersion = 1.00;
+        skipWhenMissingDependencies = 1;
+
+        units[] = {};
+        weapons[] = {};
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/addons/sogpf_ace/config.cpp
+++ b/addons/sogpf_ace/config.cpp
@@ -7,8 +7,12 @@ class CfgPatches {
         url = "https://github.com/SkippieDippie/CVO-Everything-Compats";
 
         requiredAddons[] = {
+            "armor_f_vietnam_03_c",
             "air_f_vietnam_c",
             "air_f_vietnam_02_c",
+            "air_f_vietnam_03_c",
+            "wheeled_f_vietnam_c",
+            "wheeled_f_vietnam_04_c",
             "ace_main"
         };
         requiredVersion = 1.00;

--- a/addons/sogpf_ace/config.cpp
+++ b/addons/sogpf_ace/config.cpp
@@ -24,6 +24,7 @@ class CfgPatches {
 };
 
 #include "CfgVehicles.hpp"
+#include "CfgWeapons.hpp"
 
 class ace_medical_facilities {
     SOGPF_medicalFacilities[] = {   "Land_vn_barracks_04_02",

--- a/addons/sogpf_ace/config.cpp
+++ b/addons/sogpf_ace/config.cpp
@@ -24,3 +24,21 @@ class CfgPatches {
 };
 
 #include "CfgVehicles.hpp"
+
+class ace_medical_facilities {
+    SOGPF_medicalFacilities[] = {   "Land_vn_barracks_04_02",
+                                    "Land_vn_tent_mash_01_01",
+                                    "Land_vn_tent_mash_01_02",
+                                    "Land_vn_hootch_02_01",
+                                    "Land_vn_hootch_02_11",
+                                    "Land_vn_tent_mash_02_01",
+                                    "Land_vn_tent_mash_02_02",
+                                    "Land_vn_tent_mash_02_03",
+                                    "Land_vn_tent_mash_02_04",
+                                    "Land_vn_tent_mash_01_03",
+                                    "Land_vn_tent_mash_01_04",
+                                    "Land_vn_tent_mash_01",
+                                    "Land_vn_a_hospital",
+                                    "Land_vn_wf_field_hospital_east" };
+
+};

--- a/addons/sogpf_ace/inc_CfgVehicles_Heli.hpp
+++ b/addons/sogpf_ace/inc_CfgVehicles_Heli.hpp
@@ -1,0 +1,12 @@
+class vn_helicopter_base;
+
+// CH-47 Variants
+class vn_air_ch47_transport_base;
+class vn_air_ch47_02_base: vn_air_ch47_transport_base {
+    ace_medical_treatment_patientSeats[] = {2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19};
+};
+
+// UH-1 Variants
+class vn_air_uh1d_01_base: vn_air_uh1d_base {
+    ace_medical_treatment_patientSeats[] = {0,1,2};
+};

--- a/addons/sogpf_ace/script_component.hpp
+++ b/addons/sogpf_ace/script_component.hpp
@@ -1,0 +1,14 @@
+//ADDON = cvo_compats_sogpf_ace
+
+#define COMPONENT sogpf_ace
+#include "\z\cvo_compats\addons\main\script_mod.hpp"
+
+#ifdef DEBUG_ENABLED_MAIN
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_MAIN
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_MAIN
+#endif
+
+#include "\z\cvo_compats\addons\main\script_macros.hpp"


### PR DESCRIPTION
#### When merged this pull will:
 - Configure patients seats for UH-1 Dust-Off, CH-47 Medevac, Mi-2 Medevac, M577 Ambulance, BTR-40 Ambulance, BTR-50 Ambulance and Dirt Ranger Ambulance (Closes #40);
 - Add hearing protection for Beret (RAC Headset);